### PR TITLE
Add ability to rotate based on EXIF data

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ The `image_sizes` config object supports the following fields:
   resized using bicubic interpolation.
 * `defaultProfile`: The name of a profile specified in `profiles` that should be
   the default when an embedded image tag doesn't specify a profile (see below).
-  the default when an embedded image tag doesn't specify a profile (see below).
 * `link`: True if the image should be wrapped in a link to its source file.
 This property can also be specified in the embed tag, in which case the setting
 in the embed tag will take precedence.

--- a/index.js
+++ b/index.js
@@ -32,6 +32,12 @@ hexo.extend.processor.register(hexo.config.image_sizes.pattern, function (file) 
 // record when a post uses an image and embed the image in the post.
 hexo.extend.tag.register("imsize", imsizeTag, {ends: true});
 
+// Switch the slashes in case we get Windows-style paths.
+function switchSlashes(str)
+{
+  return str.split('\\').join('/');
+}
+
 // Generate images the site has used in imsize tags
 hexo.extend.filter.register("after_generate", function() {
   let db = hexo.locals.get("image_sizes_db");
@@ -56,6 +62,10 @@ hexo.extend.filter.register("after_generate", function() {
 
       // TODO factor out this check for verb:
       let file = updatedPaths[hexoRelativeInput];
+      if (!file) {
+        file = updatedPaths[switchSlashes(hexoRelativeInput)];
+      }
+
       if (!file) {
         debug(`Unknown file:\t${hexoRelativeInput}`);
         return;

--- a/index.js
+++ b/index.js
@@ -46,7 +46,8 @@ hexo.extend.filter.register("after_generate", function() {
     let resizer = new ImageResizer(hexo, profileName, {
       "width": profile.width,
       "height": profile.height,
-      "allowEnlargement": profile.allowEnlargement
+      "allowEnlargement": profile.allowEnlargement,
+      "disableRotation": profile.disableRotation
     });
 
     let toGenerate = imagesToGenerate[profileName];

--- a/lib/ImageResizer.js
+++ b/lib/ImageResizer.js
@@ -17,6 +17,7 @@ ImageResizer.prototype.resizeRoute = function({originalRouteName, resizedRouteNa
   let width = this.options.width;
   let height = this.options.height;
   let allowEnlargement = this.options.allowEnlargement;
+  let disableRotation = this.options.disableRotation;
 
   const inputStream = this.hexo.route.get(originalRouteName);
 
@@ -33,11 +34,16 @@ ImageResizer.prototype.resizeRoute = function({originalRouteName, resizedRouteNa
     }
     return Buffer.concat(buffers);
   }).then(buffer => {
-    let resizer = sharp(buffer).resize(width, height);
-    if (!allowEnlargement) {
-      resizer.withoutEnlargement();
+    let image = sharp(buffer);
+    if (!disableRotation)
+    {
+      image = image.rotate();
     }
-    const resizedPromise = resizer.toBuffer();
+    image = image.resize(width, height);
+    if (!allowEnlargement) {
+      image = image.withoutEnlargement();
+    }
+    const resizedPromise = image.toBuffer();
     return this.hexo.route.set(resizedRouteName, () => resizedPromise);
   });
 };

--- a/lib/ImageResizer.js
+++ b/lib/ImageResizer.js
@@ -39,10 +39,11 @@ ImageResizer.prototype.resizeRoute = function({originalRouteName, resizedRouteNa
     {
       image = image.rotate();
     }
-    image = image.resize(width, height);
+    let noEnlargement = false;
     if (!allowEnlargement) {
-      image = image.withoutEnlargement();
+      noEnlargement = true;
     }
+    image = image.resize(width, height, { withoutEnlargement: noEnlargement });
     const resizedPromise = image.toBuffer();
     return this.hexo.route.set(resizedRouteName, () => resizedPromise);
   });

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "dependencies": {
     "debug": "^2.2.0",
     "hexo-util": "^0.6.0",
-    "js-yaml": "^3.6.1",
+    "js-yaml": "^3.13.1",
     "object-assign": "^4.1.0",
-    "sharp": "^0.16.0",
+    "sharp": "^0.22.1",
     "stream-to-array": "^2.3.0"
   }
 }


### PR DESCRIPTION
Thank you for sharing this very useful Hexo add-on.  I use it to generate digital photo albums and have modified it to rotate them according to their EXIF data.  This is a sane default for most people, since many modern image viewing applications will rotate images automatically.

Other changes:
- Made image generation work inside conhost (cmd.exe) command prompt on Windows 10.
- Removed a redundant line from the README.
