### PR TITLE
Enable imsize to be used in _posts directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ The `image_sizes` config object supports the following fields:
   resized using bicubic interpolation.
 * `defaultProfile`: The name of a profile specified in `profiles` that should be
   the default when an embedded image tag doesn't specify a profile (see below).
-  the default when an embedded image tag doesn't specify a profile (see below).
 * `link`: True if the image should be wrapped in a link to its source file.
 This property can also be specified in the embed tag, in which case the setting
 in the embed tag will take precedence.

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var assign = require("object-assign");
 var ImageResizer = require("./lib/ImageResizer");
 var imsizeTag = require("./lib/imsize-tag")(hexo);
 var debug = require("debug")("hexo:image_sizes");
+var Utility = require("./lib/Utility");
 
 hexo.config.image_sizes = assign({
   pattern: /\.(jpg|jpeg|png)$/i,
@@ -32,12 +33,6 @@ hexo.extend.processor.register(hexo.config.image_sizes.pattern, function (file) 
 // record when a post uses an image and embed the image in the post.
 hexo.extend.tag.register("imsize", imsizeTag, {ends: true});
 
-// Switch the slashes in case we get Windows-style paths.
-function switchSlashes(str)
-{
-  return str.split('\\').join('/');
-}
-
 // Generate images the site has used in imsize tags
 hexo.extend.filter.register("after_generate", function() {
   let db = hexo.locals.get("image_sizes_db");
@@ -63,7 +58,8 @@ hexo.extend.filter.register("after_generate", function() {
       // TODO factor out this check for verb:
       let file = updatedPaths[hexoRelativeInput];
       if (!file) {
-        file = updatedPaths[switchSlashes(hexoRelativeInput)];
+        hexoRelativeInput = Utility.pathToBackslashPath(hexoRelativeInput);
+        file = updatedPaths[hexoRelativeInput];
       }
 
       if (!file) {

--- a/index.js
+++ b/index.js
@@ -32,6 +32,12 @@ hexo.extend.processor.register(hexo.config.image_sizes.pattern, function (file) 
 // record when a post uses an image and embed the image in the post.
 hexo.extend.tag.register("imsize", imsizeTag, {ends: true});
 
+// Switch the slashes in case we get Windows-style paths.
+function switchSlashes(str)
+{
+  return str.split('\\').join('/');
+}
+
 // Generate images the site has used in imsize tags
 hexo.extend.filter.register("after_generate", function() {
   let db = hexo.locals.get("image_sizes_db");
@@ -56,6 +62,10 @@ hexo.extend.filter.register("after_generate", function() {
 
       // TODO factor out this check for verb:
       let file = updatedPaths[hexoRelativeInput];
+      if (!file) {
+        file = updatedPaths[switchSlashes(hexoRelativeInput)];
+      }
+
       if (!file) {
         debug(`Unknown file:\t${hexoRelativeInput}`);
         return;

--- a/index.js
+++ b/index.js
@@ -46,7 +46,8 @@ hexo.extend.filter.register("after_generate", function() {
     let resizer = new ImageResizer(hexo, profileName, {
       "width": profile.width,
       "height": profile.height,
-      "allowEnlargement": profile.allowEnlargement
+      "allowEnlargement": profile.allowEnlargement,
+      "disableRotation": profile.disableRotation
     });
 
     let toGenerate = imagesToGenerate[profileName];

--- a/lib/ImageResizer.js
+++ b/lib/ImageResizer.js
@@ -1,6 +1,7 @@
 let sharp = require("sharp");
 let debug = require("debug")("hexo:image_sizes");
 let streamToArray = require("stream-to-array");
+let Utility = require("./Utility");
 
 var ImageResizer = function (hexo, name, options) {
   this.hexo = hexo;
@@ -19,12 +20,22 @@ ImageResizer.prototype.resizeRoute = function({originalRouteName, resizedRouteNa
   let allowEnlargement = this.options.allowEnlargement;
   let disableRotation = this.options.disableRotation;
 
-  const inputStream = this.hexo.route.get(originalRouteName);
+  originalRouteName = Utility.pathSwapSlashes(originalRouteName);
+  var inputStream = this.hexo.route.get(originalRouteName);
 
   if (!inputStream) {
-    debug("Failed to find input stream for route", {originalRouteName});
-    return;
+    inputStream = this.hexo.route.get(Utility.pathSwapSlashes(originalRouteName));
+    if (!inputStream) {
+      inputStream = this.hexo.route.get(Utility.pathShiftPrivateDirectory(Utility.pathSwapSlashes(originalRouteName)));
+      if (!inputStream) {
+        debug("Failed to find input stream for route", {originalRouteName});
+        debug("Routes: ", this.hexo.route.list());
+        return;
+      }
+    }
   }
+
+  resizedRouteName = Utility.pathShiftPrivateDirectory(resizedRouteName);
 
   return streamToArray(inputStream).then(function (parts) {
     const buffers = [];

--- a/lib/ImageResizer.js
+++ b/lib/ImageResizer.js
@@ -17,6 +17,7 @@ ImageResizer.prototype.resizeRoute = function({originalRouteName, resizedRouteNa
   let width = this.options.width;
   let height = this.options.height;
   let allowEnlargement = this.options.allowEnlargement;
+  let disableRotation = this.options.disableRotation;
 
   const inputStream = this.hexo.route.get(originalRouteName);
 
@@ -33,11 +34,16 @@ ImageResizer.prototype.resizeRoute = function({originalRouteName, resizedRouteNa
     }
     return Buffer.concat(buffers);
   }).then(buffer => {
-    let resizer = sharp(buffer).resize(width, height);
-    if (!allowEnlargement) {
-      resizer.withoutEnlargement();
+    let image = sharp(buffer);
+    if (!disableRotation)
+    {
+      image = image.rotate();
     }
-    const resizedPromise = resizer.toBuffer();
+    image = image.resize(width, height);
+    if (!allowEnlargement) {
+      image = image.withoutEnlargement();
+    }
+    const resizedPromise = image.toBuffer();
     return this.hexo.route.set(resizedRouteName, () => resizedPromise);
   });
 };

--- a/lib/ImageResizer.js
+++ b/lib/ImageResizer.js
@@ -39,10 +39,11 @@ ImageResizer.prototype.resizeRoute = function({originalRouteName, resizedRouteNa
     {
       image = image.rotate();
     }
-    image = image.resize(width, height);
+    let noEnlargement = false;
     if (!allowEnlargement) {
-      image = image.withoutEnlargement();
+      noEnlargement = true;
     }
+    image = image.resize(width, height, { withoutEnlargement: noEnlargement });
     const resizedPromise = image.toBuffer();
     return this.hexo.route.set(resizedRouteName, () => resizedPromise);
   });

--- a/lib/Utility.js
+++ b/lib/Utility.js
@@ -1,0 +1,67 @@
+let debug = require("debug")("hexo:image_sizes");
+
+/**
+ * Convert a string (a file path) to a file path that uses backslashes
+ */
+function pathToBackslashPath(pathString) {
+  return pathString.split('\\').join('/');
+};
+
+/**
+ * Switch the slashes in case we get Windows-style paths.
+ */
+function pathSwapSlashes(str) {
+  let delim = '/';
+  let newDelim = '\\';
+  if (str.split(delim).length <= 1)
+  {
+    delim = '\\';
+    newDelim = '/';
+  }
+
+  if (str.split(delim).length <= 1)
+  {
+    return str;
+  }
+  else
+  {
+    return str.split(delim).join(newDelim);
+  }
+}
+
+/**
+ * Shift the private directory out from the front of the path.  Given a
+ * relative input path, remove leading directory in the path if it includes an
+ * underscore
+ *
+ * Example:
+ *    input: _posts/test1/image.jpg
+ *   return: test1/image.jpg
+ */
+function pathShiftPrivateDirectory(inputPath) {
+  let delim = '/';
+  let array = inputPath.split(delim);
+  if (array.length > 1) {
+  }
+  else
+  {
+    delim = '\\';
+    array = inputPath.split(delim);
+  }
+
+  if (array.length > 1) {
+    if ('_' === array[0].charAt(0)) {
+      array.shift();
+      return array.join(delim);
+    }
+  }
+  return inputPath;
+};
+
+let functions = {
+  pathToBackslashPath,
+  pathSwapSlashes,
+  pathShiftPrivateDirectory,
+};
+
+module.exports = functions;

--- a/lib/imsize-tag.js
+++ b/lib/imsize-tag.js
@@ -2,6 +2,7 @@ let path = require("path");
 let debug = require("debug")("hexo:image_sizes");
 let yaml = require("js-yaml");
 let hexoUtil = require("hexo-util");
+let Utility = require("./Utility");
 
 /*
 Try to find the given profile `name` in `profiles` to make sure it exists. If
@@ -128,14 +129,19 @@ function factory (hexo) {
     let absoluteResizedImagePath = absoluteOutputPath(absoluteInput, profileName, hexoSourceDir, hexoPublicDir);
     let hexoRelativeResizedImagePath = path.relative(hexoPublicDir, absoluteResizedImagePath);
 
+    // Switch slashes backslashes ('/') in case they are not already (e.g.
+    // you are running Windows)
+    hexoRelativeResizedImagePath = Utility.pathToBackslashPath(hexoRelativeResizedImagePath);
+
     // Add this image to the db so we will create it later
     addImageToGenerate(profileName, {
       hexoRelativeInput,
       hexoRelativeOutput: hexoRelativeResizedImagePath,
     });
 
+    let srcPath = Utility.pathToBackslashPath(Utility.pathShiftPrivateDirectory(hexoRelativeResizedImagePath));
     let attrs = {
-      src: "/" + hexoRelativeResizedImagePath,
+      src: "/" + srcPath,
     };
 
     // Add optional properties
@@ -150,13 +156,20 @@ function factory (hexo) {
 
     if (shouldLink) {
       linkProfile = resolveProfileName(config, linkProfile);
+      if (null === linkProfile) {
+        debug("Link image is original");
+        linkImageIsOriginal = true;
+      }
       let absoluteLinkTargetImagePath = absoluteOutputPath(absoluteInput, linkProfile, hexoSourceDir, hexoPublicDir);
       let hexoRelativeLinkTargetImagePath = path.relative(hexoPublicDir, absoluteLinkTargetImagePath);
       addImageToGenerate(linkProfile, {
         hexoRelativeInput,
         hexoRelativeOutput: hexoRelativeLinkTargetImagePath,
       });
-      html = `<a href="/${hexoRelativeLinkTargetImagePath}">${html}</a>`;
+      // Making the filesystem-relative path into a public-relative path
+      // may involve stripping the _posts folder from the path.
+      let siteAbsoluteLinkTargetImagePath = '/' + Utility.pathShiftPrivateDirectory(hexoRelativeLinkTargetImagePath);
+      html = `<a href="${siteAbsoluteLinkTargetImagePath}">${html}</a>`;
     }
 
     return html;

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "dependencies": {
     "debug": "^2.2.0",
     "hexo-util": "^0.6.0",
-    "js-yaml": "^3.6.1",
+    "js-yaml": "^3.13.1",
     "object-assign": "^4.1.0",
-    "sharp": "^0.16.0",
+    "sharp": "^0.22.1",
     "stream-to-array": "^2.3.0"
   }
 }


### PR DESCRIPTION
This patch corrects broken links generated by hexo-image-sizes in the scenario where  `post_asset_folder: true` and the folder is a child of `source/_posts`.

Prior to this patch the` {% imsize %}` tags produce broken links when used inside the _posts directory.  These links are broken because they include `/_posts/` as a prefix to the src image.

Hexo removes the _posts prefix and replaces it with the permalink path specified in the config file.  Prior to this patch, hexo-image-sizes does not know to do this.  This patch introduces new behavior to remove the _posts directory if it is present in the source path.

Note that this fix has only been verified in two scenarios (`hexo new page` and `hexo new post`), and only on my Windows machine.

Also note that I have not separated this patch from my previous chain of fixes, since I am currently running Windows.  I can produce a separated patch for upstreaming if you can test it.